### PR TITLE
Remove DartNode banner from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 <img src="https://3ofrpz7mhw.ufs.sh/f/9h8vN5CCYibJCfOnkrzL5RTenxN0PakwUA41YgmtJo8ZrK7C" alt="FearlessCMS Logo" style="width:200px"></img>
 </p>
 
-[![Powered by DartNode](https://dartnode.com/branding/DN-Open-Source-sm.png)](https://dartnode.com "Powered by DartNode - Free VPS for Open Source")
-
 Welcome to FearlessCMS, a new content management system centered around simplicity and respect for the open source community. The project is currently in beta testing stages, so while it is becoming more robust, please report any issues you find.
 
 ## ✍️ HTML Editing with Markdown Support


### PR DESCRIPTION
Removed powered by DartNode banner from README.